### PR TITLE
Add GitHub Skills activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Wednesdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This pull request adds the "GitHub Skills" activity to the activities list in the backend.

- Name: GitHub Skills
- Description: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.
- Schedule: Wednesdays, 4:00 PM - 5:00 PM
- Max participants: 25
- Participants: (empty by default)

Closes #6.